### PR TITLE
Fix extend example: :extend refer to previously declared button-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Extend existing functions:
    :padding (px 12)})
 
 (defn red-button-style []
-  ^{:extend [button "white"]}
+  ^{:extend [button-style "white"]}
   {:background-color "red"})
 
 (defn button []


### PR DESCRIPTION
Seems like there is a typo in the example

Thanks for the lib, it seems great!